### PR TITLE
Fix path separator on windows where Webpack still uses `/`

### DIFF
--- a/test-play-project/project/build.properties
+++ b/test-play-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.1.6

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0"
+version in ThisBuild := "1.2.0"


### PR DESCRIPTION
Webpack's artifact still uses `/` (even on windows)

This fixes: #13