### PR TITLE
Upgrade dependency versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,4 +28,4 @@ licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT")))
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 
-addSbtJsEngine("1.2.2")
+addSbtJsEngine("1.2.3")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/test-play-project/project/build.properties
+++ b/test-play-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/test-play-project/project/plugin.sbt
+++ b/test-play-project/project/plugin.sbt
@@ -4,4 +4,4 @@ lazy val sbtVuefy = RootProject(file("./..").getCanonicalFile.toURI)
 
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")


### PR DESCRIPTION
When upgrading Play to 2.6.21, we get this warning:

```
[WARN] [01/17/2019 02:12:11.787] [main] [ManifestInfo(akka://sbt-web)] Detected possible incompatible versions on the classpath. Please note that a given Akka version MUST be the same across all modules of Akka that you are using, e.g. if you use [2.5.18] all other modules that are released together MUST be of the same version. Make sure you're using a compatible set of libraries.Possibly conflicting versions [2.5.11, 2.5.18] in libraries [akka-protobuf:2.5.11, akka-actor:2.5.18, akka-slf4j:2.5.11, akka-stream:2.5.11]
```